### PR TITLE
Add support for GUID primary keys in SQL Server CE 4

### DIFF
--- a/MigSharp/Providers/SqlServerCe4Provider.cs
+++ b/MigSharp/Providers/SqlServerCe4Provider.cs
@@ -19,7 +19,7 @@ namespace MigSharp.Providers
     [Supports(DbType.Decimal, MaximumSize = 28, MaximumScale = 28)] // this is a restriction of the decimal type of the CLR (see http://support.microsoft.com/kb/932288)
     [Supports(DbType.Decimal, MaximumSize = 28)] // this is a restriction of the decimal type of the CLR (see http://support.microsoft.com/kb/932288)
     [Supports(DbType.Double)]
-    [Supports(DbType.Guid)]
+    [Supports(DbType.Guid, CanBeUsedAsPrimaryKey = true)]
     [Supports(DbType.Int16)]
     [Supports(DbType.Int32, CanBeUsedAsPrimaryKey = true)]
     [Supports(DbType.Int64, CanBeUsedAsPrimaryKey = true)]


### PR DESCRIPTION
Hi, I have a change I hope you will incorporate, which allows GUIDs to be used as primary keys with SQL Server CE 4.

I really enjoy using Mig#. Thanks for your work.

Regards,

Matt Lester
