### PR TITLE
ANSI SQL quoting does not work on SQL Server (use square brackets instead of double quotes)

### DIFF
--- a/MigSharp.NUnit/Process/PersistedVersioningTests.cs
+++ b/MigSharp.NUnit/Process/PersistedVersioningTests.cs
@@ -9,6 +9,8 @@ using Rhino.Mocks;
 
 namespace MigSharp.NUnit.Process
 {
+    using MigSharp.Providers;
+
     [TestFixture, Category("smoke")]
     public class PersistedVersioningTests
     {
@@ -35,7 +37,7 @@ namespace MigSharp.NUnit.Process
 
         private static PersistedVersioning CreateVersioning()
         {
-            var history = new History("TableName", MockRepository.GenerateStub<IProviderMetadata>());
+            var history = new History("TableName", MockRepository.GenerateStub<IProviderMetadata>(), MockRepository.GenerateStub<IProvider>());
             history.LoadEntry(ExistingTimestampForDefaultModule, string.Empty, ExistingTagForDefaultModule);
             history.LoadEntry(ExistingTimestampForTestModule, TestModule, ExistingTagForTestModule);
             return new PersistedVersioning(history);

--- a/MigSharp.NUnit/Process/ValidatorTests.cs
+++ b/MigSharp.NUnit/Process/ValidatorTests.cs
@@ -345,6 +345,11 @@ namespace MigSharp.NUnit.Process
                 throw new NotSupportedException();
             }
 
+            public string Escape(string name)
+            {
+                return string.Format("\"{0}\"", name);
+            }
+
             #endregion
         }
     }

--- a/MigSharp.SqlServer.NUnit/SmoProvider.cs
+++ b/MigSharp.SqlServer.NUnit/SmoProvider.cs
@@ -324,6 +324,11 @@ namespace MigSharp.SqlServer.NUnit
             return ScriptChanges(table.Parent.Parent);
         }
 
+        public string Escape(string name)
+        {
+            return string.Format("[{0}]", name);
+        }
+
         private static IEnumerable<string> DropConstraint(string tableName, string constraintName, IndexKeyType keyType)
         {
             Table table = GetTable(tableName);

--- a/MigSharp/IProviderMetaData.cs
+++ b/MigSharp/IProviderMetaData.cs
@@ -35,6 +35,11 @@ namespace MigSharp
         /// Gets the maximum length of object names within the database. 0 meaning that there is non restriction which is the default.
         /// </summary>
         int MaximumDbObjectNameLength { get; }
+
+        ///// <summary>
+        ///// Gets the identifier pattern for the database.
+        ///// </summary>
+        //string IdentifierPattern { get; }
     }
 
     internal static class ProviderMetadataExtensions

--- a/MigSharp/Process/History.cs
+++ b/MigSharp/Process/History.cs
@@ -103,11 +103,11 @@ namespace MigSharp.Process
                 command.Transaction = transaction;
                 IDataParameter moduleNameParameter = command.AddParameter("@ModuleName", DbType.String, entry.ModuleName);
                 IDataParameter tagParameter = command.AddParameter("@Tag", DbType.String, !string.IsNullOrEmpty(entry.Tag) ? (object)entry.Tag : DBNull.Value);
-                command.CommandText = string.Format(CultureInfo.InvariantCulture, @"INSERT INTO {0} ({1}, {2}, {3}) VALUES ({4}, {5}, {6})",
-                    _provider.Escape(_tableName),
-                    _provider.Escape(BootstrapMigration.TimestampColumnName),
-                    _provider.Escape(BootstrapMigration.ModuleColumnName),
-                    _provider.Escape(BootstrapMigration.TagColumnName),
+                command.CommandText = string.Format(CultureInfo.InvariantCulture, @"INSERT INTO ""{0}"" (""{1}"", ""{2}"", ""{3}"") VALUES ({4}, {5}, {6})",
+                    _tableName,
+                    BootstrapMigration.TimestampColumnName,
+                    BootstrapMigration.ModuleColumnName,
+                    BootstrapMigration.TagColumnName,
                     entry.Timestamp.ToString(CultureInfo.InvariantCulture),
                     _providerMetadata.GetParameterSpecifier(moduleNameParameter),
                     _providerMetadata.GetParameterSpecifier(tagParameter));

--- a/MigSharp/Process/Versioning.cs
+++ b/MigSharp/Process/Versioning.cs
@@ -65,7 +65,7 @@ namespace MigSharp.Process
         {
             if (_persistedVersioning == null)
             {
-                var history = new History(_versioningTableName, _providerMetadata);
+                var history = new History(_versioningTableName, _providerMetadata, _provider);
                 if (!_versioningTableExists.Value)
                 {
                     Debug.Assert(connection != null, "At this point, an upgrade of the versioning table is requested. This always takes part of a running migration step and therefore already has an associated connection (and possibly a transaction).");

--- a/MigSharp/Providers/IProvider.cs
+++ b/MigSharp/Providers/IProvider.cs
@@ -129,6 +129,13 @@ namespace MigSharp.Providers
         /// </summary>
         /// <returns>The SQL commands to be executed.</returns>
         IEnumerable<string> DropDefault(string tableName, Column column);
+
+        /// <summary>
+        /// Return escaped name
+        /// </summary>
+        /// <param name="name">value to escape</param>
+        /// <returns></returns>
+        string Escape(string name);
     }
 
     internal static class ProviderExtensions

--- a/MigSharp/Providers/OracleProvider.cs
+++ b/MigSharp/Providers/OracleProvider.cs
@@ -124,7 +124,7 @@ namespace MigSharp.Providers
             return comands;
         }
 
-        private static string CreateTrigger(string tableName, string identityColumn, string sequenceName)
+        private string CreateTrigger(string tableName, string identityColumn, string sequenceName)
         {
             return string.Format(CultureInfo.InvariantCulture, @"CREATE TRIGGER ""{0}"" BEFORE INSERT ON {1} FOR EACH ROW BEGIN SELECT ""{3}"".NEXTVAL into :new.{2} FROM dual; END;",
                 GetTriggerName(tableName),
@@ -296,7 +296,7 @@ namespace MigSharp.Providers
             yield return string.Format(CultureInfo.InvariantCulture, query, tableName, column.Name, GetTypeSpecifier(column.DataType), colN, colY, defaultConstraintClause);
         }
 
-        private static IEnumerable<string> DropConstraint(string tableName, string constraintName)
+        private IEnumerable<string> DropConstraint(string tableName, string constraintName)
         {
             yield return string.Format(CultureInfo.InvariantCulture, "{0} DROP CONSTRAINT {1}", AlterTable(tableName), Escape(constraintName));
         }
@@ -343,7 +343,7 @@ namespace MigSharp.Providers
             yield return string.Format(CultureInfo.InvariantCulture, "{0} RENAME TO {1}", AlterIndex(oldName), Escape(newName));
         }
 
-        private static string AlterIndex(string indexName)
+        private string AlterIndex(string indexName)
         {
             return string.Format(CultureInfo.InvariantCulture, "ALTER INDEX {0}", Escape(indexName));
         }
@@ -369,17 +369,17 @@ namespace MigSharp.Providers
             return AlterColumn(tableName, column);
         }
 
-        private static string CreateTable(string tableName)
+        private string CreateTable(string tableName)
         {
             return string.Format(CultureInfo.InvariantCulture, "CREATE TABLE {0}", Escape(tableName));
         }
 
-        private static string AlterTable(string tableName)
+        private string AlterTable(string tableName)
         {
             return string.Format(CultureInfo.InvariantCulture, "ALTER TABLE {0}", Escape(tableName));
         }
 
-        private static string Escape(string name)
+        public string Escape(string name)
         {
             return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", name);
         }
@@ -455,7 +455,7 @@ namespace MigSharp.Providers
             }
         }
 
-        private static string GetCsList(IEnumerable<string> columnNames)
+        private string GetCsList(IEnumerable<string> columnNames)
         {
             string columns = String.Empty;
             foreach (var column in columnNames)

--- a/MigSharp/Providers/RecordingProvider.cs
+++ b/MigSharp/Providers/RecordingProvider.cs
@@ -181,6 +181,11 @@ namespace MigSharp.Providers
             return Enumerable.Empty<string>();
         }
 
+        public string Escape(string name)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", name);
+        }
+
         #endregion
 
         private void AddNewObjectNames(params string[] names)

--- a/MigSharp/Providers/SQLiteProvider.cs
+++ b/MigSharp/Providers/SQLiteProvider.cs
@@ -215,6 +215,11 @@ namespace MigSharp.Providers
             throw new NotSupportedException("Rename the table, create a new table with the correct columns, and copy the contents from the renamed table.");
         }
 
+        public string Escape(string name)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", name);
+        }
+
         private static string GetTypeSpecifier(DataType type)
         {
             switch (type.DbType)

--- a/MigSharp/Providers/SqlServerProviderBase.cs
+++ b/MigSharp/Providers/SqlServerProviderBase.cs
@@ -267,7 +267,7 @@ namespace MigSharp.Providers
             return string.Format(CultureInfo.InvariantCulture, "ALTER TABLE {0}{1}", Dbo, Escape(tableName));
         }
 
-        protected static string Escape(string name)
+        public string Escape(string name)
         {
             return string.Format(CultureInfo.InvariantCulture, "[{0}]", name);
         }

--- a/MigSharp/Providers/TeradataProvider.cs
+++ b/MigSharp/Providers/TeradataProvider.cs
@@ -144,7 +144,7 @@ namespace MigSharp.Providers
             yield return string.Format(string.Format("{0} ADD {1}", AlterTable(tableName), GetColumnString(column, false)));
         }
 
-        private static IEnumerable<string> DropConstraint(string tableName, string constraintName)
+        private IEnumerable<string> DropConstraint(string tableName, string constraintName)
         {
             yield return string.Format("{0} DROP CONSTRAINT {1}", AlterTable(tableName), Escape(constraintName));
         }
@@ -216,17 +216,17 @@ namespace MigSharp.Providers
             return AlterColumn(tableName, column);
         }
 
-        private static string CreateTable(string tableName)
+        private string CreateTable(string tableName)
         {
             return string.Format(CultureInfo.InvariantCulture, "CREATE TABLE {0}", Escape(tableName));
         }
 
-        private static string AlterTable(string tableName)
+        private string AlterTable(string tableName)
         {
             return string.Format(CultureInfo.InvariantCulture, "ALTER TABLE {0}", Escape(tableName));
         }
 
-        private static string Escape(string name)
+        public string Escape(string name)
         {
             return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", name);
         }
@@ -346,7 +346,7 @@ namespace MigSharp.Providers
             return Convert.ToString(value, CultureInfo.InvariantCulture);
         }
 
-        private static string GetCsList(IEnumerable<string> columnNames)
+        private string GetCsList(IEnumerable<string> columnNames)
         {
             string columns = String.Empty;
             foreach (var column in columnNames)


### PR DESCRIPTION
To execute the MigSharp insert table properly it was added the Espace
method to IProvider and in History class this escape is used to prevent
errors.
